### PR TITLE
북마크 가져오기 이미지 최적화

### DIFF
--- a/AIProject/iCo/Core/Util/UIImage+Util.swift
+++ b/AIProject/iCo/Core/Util/UIImage+Util.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension UIImage {
-    func optimizeImages() -> (display: UIImage, ocr: CGImage)? {
+    func resizeImageIfNeeded() -> UIImage? {
         let maxDimension: CGFloat = 1024
         let currentMax = max(size.width, size.height)
         
@@ -26,15 +26,11 @@ extension UIImage {
             
             // 새로운 사이즈로 이미지 렌더링하기
             let renderer = UIGraphicsImageRenderer(size: newSize)
-            let displayImage = renderer.image { _ in
+            return renderer.image { _ in
                 self.draw(in: CGRect(origin: .zero, size: newSize))
             }
-            
-            guard let ocrImage = displayImage.cgImage else { return nil }
-            return (displayImage, ocrImage)
         } else {
-            guard let ocrImage = self.cgImage else { return nil }
-            return (self, ocrImage)
+            return self
         }
     }
 }

--- a/AIProject/iCo/Core/Util/UIImage+Util.swift
+++ b/AIProject/iCo/Core/Util/UIImage+Util.swift
@@ -1,0 +1,40 @@
+//
+//  UIImage+Util.swift
+//  iCo
+//
+//  Created by Kitcat Seo on 9/10/25.
+//
+
+import SwiftUI
+
+extension UIImage {
+    func optimizeImages() -> (display: UIImage, ocr: CGImage)? {
+        let maxDimension: CGFloat = 1024
+        let currentMax = max(size.width, size.height)
+        
+        // 이미지가 기준 사이즈보다 크면 리사이징하기
+        if currentMax > maxDimension {
+            let aspectRatio = size.width / size.height
+            var newSize: CGSize
+            
+            // 원본 이미지 비율에 맞게 사이즈 책정하기
+            if aspectRatio > 1 {
+                newSize = CGSize(width: maxDimension, height: maxDimension / aspectRatio)
+            } else {
+                newSize = CGSize(width: maxDimension * aspectRatio, height: maxDimension)
+            }
+            
+            // 새로운 사이즈로 이미지 렌더링하기
+            let renderer = UIGraphicsImageRenderer(size: newSize)
+            let displayImage = renderer.image { _ in
+                self.draw(in: CGRect(origin: .zero, size: newSize))
+            }
+            
+            guard let ocrImage = displayImage.cgImage else { return nil }
+            return (displayImage, ocrImage)
+        } else {
+            guard let ocrImage = self.cgImage else { return nil }
+            return (self, ocrImage)
+        }
+    }
+}

--- a/AIProject/iCo/Core/Util/Vision/TextRecognitionHelper.swift
+++ b/AIProject/iCo/Core/Util/Vision/TextRecognitionHelper.swift
@@ -10,10 +10,10 @@ import Vision
 import NaturalLanguage
 
 final class TextRecognitionHelper {
-    private var image: UIImage?
+    private var image: CGImage?
     private var coinNames: Set<String>
     
-    init(image: UIImage, coinNames: Set<String>) {
+    init(image: CGImage, coinNames: Set<String>) {
         self.image = image
         self.coinNames = coinNames
     }
@@ -26,9 +26,7 @@ final class TextRecognitionHelper {
     
     /// OCR을 처리하는 함수
     func recognizeText() async throws -> [String] {
-        guard let cgImage = image?.cgImage else {
-            throw NSError(domain: "TextRecognitionError", code: -1, userInfo: [NSLocalizedDescriptionKey: "🚨 CGImage가 유효하지 않음"])
-        }
+        guard let image else { throw ImageProcessError.unknownVisionError }
         
         return try await withCheckedThrowingContinuation { continuation in
             let request = VNRecognizeTextRequest { [weak self] request, error in
@@ -56,7 +54,7 @@ final class TextRecognitionHelper {
             request.usesLanguageCorrection = true
             request.revision = VNRecognizeTextRequestRevision3
             
-            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            let handler = VNImageRequestHandler(cgImage: image, options: [:])
             do {
                 try handler.perform([request])
             } catch {

--- a/AIProject/iCo/Core/Util/Vision/TextRecognitionHelper.swift
+++ b/AIProject/iCo/Core/Util/Vision/TextRecognitionHelper.swift
@@ -22,6 +22,12 @@ final class TextRecognitionHelper {
         
         return try await withCheckedThrowingContinuation { continuation in
             let request = VNRecognizeTextRequest { [weak self] request, error in
+                // continuation에서 에러를 반환하면 안전하게 종료하기
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
                 // DataRace로 인한 참조 해제가 발생하면 안전하게 종료하기
                 guard self != nil else {
                     continuation.resume(throwing: ImageProcessError.unknownVisionError)
@@ -31,12 +37,6 @@ final class TextRecognitionHelper {
                 // 메모리 부족 등으로 Vision 처리 자체가 실패하면 안전하게 종료하기
                 guard let observations = request.results as? [VNRecognizedTextObservation] else {
                     continuation.resume(throwing: ImageProcessError.unknownVisionError)
-                    return
-                }
-                
-                // continuation에서 에러를 반환하면 안전하게 종료하기
-                if let error {
-                    continuation.resume(throwing: error)
                     return
                 }
                 

--- a/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
@@ -117,7 +117,6 @@ struct CoinCarouselView: View {
             handleManualScrolling(cardID: newValue)
         }
         .sheet(item: $selectedCoin) { coin in
-            
             VStack(spacing: 0) {
                 ZStack(alignment: .center) {
                     HeaderView(

--- a/AIProject/iCo/Features/MyPage/View/BookmarkBulkInsert/ContentSection.swift
+++ b/AIProject/iCo/Features/MyPage/View/BookmarkBulkInsert/ContentSection.swift
@@ -12,20 +12,22 @@ struct ContentSection: View {
     @ObservedObject var vm: ImageProcessViewModel
     
     @State var selectedItem: PhotosPickerItem?
-    @State var selectedImage: UIImage?
+    @State var displayImage: UIImage?
     
     var body: some View {
         VStack(spacing: 18) {
             Spacer()
             
             VStack {
-                if selectedImage == nil {
+                if displayImage == nil {
                     // 이미지 등록 전
                     CommonPlaceholderView(imageName: "placeholder-no-image", text: "선택된 이미지가 없어요")
                 } else {
                     // 이미지 등록 후
                     ZStack {
-                        ImagePreviewView(selectedImage: selectedImage!)
+                        if let displayImage {
+                            ImagePreviewView(selectedImage: displayImage)
+                        }
                         
                         if vm.isLoading {
                             VStack(spacing: 16) {
@@ -59,10 +61,16 @@ struct ContentSection: View {
             .padding(.horizontal, 16)
             .onChange(of: selectedItem) { _, newValue in
                 Task {
-                    if let data = try? await newValue?.loadTransferable(type: Data.self),
-                       let uiImage = UIImage(data: data) {
-                        selectedImage = uiImage
-                        vm.processImage(from: selectedImage!)
+                    if let photoPickerItem = newValue,
+                       let data = try? await photoPickerItem.loadTransferable(type: Data.self),
+                       let originalImage = UIImage(data: data),
+                       let optimizeImages = originalImage.optimizeImages() {
+                        // 미리보기 표시용 리사이즈 이미지
+                        displayImage = optimizeImages.display
+                        
+                        // OCR 작업 용 최적화 이미지
+                        let ocrImage = optimizeImages.ocr
+                        vm.processImage(from: ocrImage)
                     }
                 }
             }

--- a/AIProject/iCo/Features/MyPage/View/BookmarkBulkInsert/ContentSection.swift
+++ b/AIProject/iCo/Features/MyPage/View/BookmarkBulkInsert/ContentSection.swift
@@ -64,12 +64,12 @@ struct ContentSection: View {
                     if let photoPickerItem = newValue,
                        let data = try? await photoPickerItem.loadTransferable(type: Data.self),
                        let originalImage = UIImage(data: data),
-                       let optimizeImages = originalImage.optimizeImages() {
+                       let optimizedImage = originalImage.resizeImageIfNeeded() {
                         // 미리보기 표시용 리사이즈 이미지
-                        displayImage = optimizeImages.display
+                        displayImage = optimizedImage
                         
                         // OCR 작업 용 최적화 이미지
-                        let ocrImage = optimizeImages.ocr
+                        guard let ocrImage = optimizedImage.cgImage else { return }
                         vm.processImage(from: ocrImage)
                     }
                 }

--- a/AIProject/iCo/Features/MyPage/ViewModel/ImageProcessViewModel.swift
+++ b/AIProject/iCo/Features/MyPage/ViewModel/ImageProcessViewModel.swift
@@ -125,7 +125,11 @@ class ImageProcessViewModel: ObservableObject {
         
         do {
             guard let ocrImage else { return [String]() }
-            let recognizedText = try await TextRecognitionHelper(image: ocrImage, coinNames: coinNames).handleOCR()
+            let recognizedText = try await TextRecognitionHelper()
+                .handleOCR(
+                    from: ocrImage,
+                    with: coinNames
+                )
             
             return recognizedText
         } catch is CancellationError {

--- a/AIProject/iCo/Features/MyPage/ViewModel/ImageProcessViewModel.swift
+++ b/AIProject/iCo/Features/MyPage/ViewModel/ImageProcessViewModel.swift
@@ -30,7 +30,7 @@ class ImageProcessViewModel: ObservableObject {
     @Published var verifiedCoinList = [CoinDTO]()
     
     /// 북마크 대량 등록을 위해 이미지에 대한 비동기 처리를 컨트롤하는 함수
-    func processImage(from selectedImage: UIImage) {
+    func processImage(from selectedImage: CGImage) {
         processImageTask = Task {
             await MainActor.run {
                 isLoading = true
@@ -114,18 +114,18 @@ class ImageProcessViewModel: ObservableObject {
     }
     
     /// 전달된 이미지에 OCR을 처리하고 비식별화된 문자열 배열을 받아오는 함수
-    private func performOCR(from selectedImage: UIImage, with coinNames: Set<String>) async throws -> [String] {
-        var originalImage: UIImage? = selectedImage
+    private func performOCR(from selectedImage: CGImage, with coinNames: Set<String>) async throws -> [String] {
+        var ocrImage: CGImage? = selectedImage
         
         try Task.checkCancellation()
         
         defer {
-            originalImage = nil
+            ocrImage = nil
         }
         
         do {
-            guard let originalImage else { return [String]() }
-            let recognizedText = try await TextRecognitionHelper(image: originalImage, coinNames: coinNames).handleOCR()
+            guard let ocrImage else { return [String]() }
+            let recognizedText = try await TextRecognitionHelper(image: ocrImage, coinNames: coinNames).handleOCR()
             
             return recognizedText
         } catch is CancellationError {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- 메모리 사용 최적화를 위해 이미지 관련 Util 추가
  - 이미지 사이즈 제한 : 최대 1024px로 렌더링
  - 미리보기 뷰에 띄울 Display용 이미지와 OCR용 이미지로 분리
  - CGImage로 변환하는 시점 당기기 : CGImage가 상대적으로 저용량
- PhotoPicker 이미지 관련 불필요한 강제 언래핑 제거

### 스크린샷 (선택)

실제 기기 (iPhone 11) 기준 테스트 결과

| 적용 전 | 적용 후 |
| ------ | ------ |
| <img width="300" alt="Screenshot 2025-09-10 at 2 12 57 pm" src="https://github.com/user-attachments/assets/fbb2f87e-92c6-4062-8214-d061eec5f8aa" /> | <img width="300" alt="Screenshot 2025-09-10 at 2 10 58 pm" src="https://github.com/user-attachments/assets/83ec5e8d-4c7f-40e6-a08b-28bfc4c46796" /> |

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

실제 메모리 수치는 이미지나 기기 성능에 영향을 받습니다.
강사님께서 메모리 점검은 늘 실 기기로 테스트하라고 하셔서 테스트하실 분들은 실기기로 테스트해주세요!