### PR TITLE
Feature/network monitor banner kh

### DIFF
--- a/AIProject/iCo/App/Source/iCoApp.swift
+++ b/AIProject/iCo/App/Source/iCoApp.swift
@@ -19,29 +19,32 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct iCoApp: App {
     let persistenceController = PersistenceController.shared
     @AppStorage("hasSeenOnboarding") var hasSeenOnboarding: Bool = false
-    
+
     // register app delegate for Firebase setup
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
     @StateObject private var themeManager = ThemeManager()
     @StateObject private var recommendCoinViewModel = RecommendCoinViewModel()
     @State private var coinStore: CoinStore = .init(
         coinService: DefaultCoinService(network: NetworkClient())
     )
-    
+
+    @State private var connectivity = ConnectivityMonitor()
+    @State private var appManager: AppConnectivityManager!
+
     private let coinService: UpBitAPIService = UpBitAPIService()
     private let tickerService: RealTimeTickerProvider = UpbitTickerService()
-    
+
     @State private var isLoading = true
-    
+
     var body: some Scene {
         WindowGroup {
             ZStack {
                 if isLoading {
                     SplashScreenView(isLoading: $isLoading)
                         .transition(.asymmetric(
-                          insertion: .identity,
-                          removal: .opacity.animation(.easeOut(duration: 0.3))
+                            insertion: .identity,
+                            removal: .opacity.animation(.easeOut(duration: 0.3))
                         ))
                         .zIndex(1)
                         .environmentObject(recommendCoinViewModel)
@@ -51,9 +54,13 @@ struct iCoApp: App {
                             tickerService: tickerService,
                             coinService: coinService
                         )
-                            .environment(\.managedObjectContext, persistenceController.container.viewContext)
-                            .environmentObject(themeManager)
-                            .environmentObject(recommendCoinViewModel)
+                        .safeAreaInset(edge: .top, content: {
+                            TopBannerView(controller: appManager.banner)
+                                .animation(.snappy, value: appManager.banner.isVisible)
+                        })
+                        .environment(\.managedObjectContext, persistenceController.container.viewContext)
+                        .environmentObject(themeManager)
+                        .environmentObject(recommendCoinViewModel)
                     } else {
                         OnboardingView()
                             .environmentObject(recommendCoinViewModel)
@@ -61,6 +68,11 @@ struct iCoApp: App {
                 }
             }
             .environment(coinStore)
+            .onAppear {
+                if appManager == nil {
+                    appManager = AppConnectivityManager(connectivity: connectivity)
+                }
+            }
         }
     }
 }
@@ -70,14 +82,14 @@ struct SplashScreenView: View {
     @Binding var isLoading: Bool
     @EnvironmentObject var recommendCoinViewModel: RecommendCoinViewModel
     @Environment(CoinStore.self) var coinStore
-    
+
     var body: some View {
         ZStack {
             Image("launchscreen-bg")
                 .resizable()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
-            
+
             Image("logo")
                 .resizable()
                 .scaledToFit()

--- a/AIProject/iCo/Core/Remote/NetworkMonitor.swift
+++ b/AIProject/iCo/Core/Remote/NetworkMonitor.swift
@@ -1,0 +1,39 @@
+//
+//  NetworkMonitor.swift
+//  iCo
+//
+//  Created by Kanghos on 9/17/25.
+//
+
+import Network
+import Observation
+
+@Observable
+final class ConnectivityMonitor {
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "net.connectivity")
+
+    private(set) var isOnline: Bool = true
+    /// Cellular, Hotspot
+    private(set) var isExpensive: Bool = false
+    /// 네트워크 절약 모드
+    private(set) var isConstrained: Bool = false
+    /// wifi, cellular
+    private(set) var interface: NWInterface.InterfaceType? = nil
+
+    private var continuation: CheckedContinuation<Bool, Never>?
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            self.isOnline = (path.status == .satisfied)
+            self.isExpensive = path.isExpensive
+            self.isConstrained = path.isConstrained
+            self.interface = path.availableInterfaces
+                .first(where: { path.usesInterfaceType($0.type) })?.type
+        }
+        monitor.start(queue: queue)
+    }
+
+    deinit { monitor.cancel() }
+}

--- a/AIProject/iCo/Features/Base/Banner/AppConnectivityManager.swift
+++ b/AIProject/iCo/Features/Base/Banner/AppConnectivityManager.swift
@@ -1,0 +1,36 @@
+//
+//  AppConnectivityManager.swift
+//  iCo
+//
+//  Created by Kanghos on 9/18/25.
+//
+
+import Foundation
+
+@Observable
+final class AppConnectivityManager {
+    let banner = TopBannerController()
+    private let connectivity: ConnectivityMonitor
+
+    init(connectivity: ConnectivityMonitor) {
+        self.connectivity = connectivity
+        Task { [weak self] in
+            guard let self else { return }
+            var last = connectivity.isOnline
+
+            while true {
+                try? await Task.sleep(nanoseconds: 400_000_000) // 0.4s 마다 감지
+                let now = self.connectivity.isOnline
+                guard now != last else { continue }
+                last = now
+                await MainActor.run {
+                    if now {
+                        self.banner.showOnline("온라인 복귀")
+                    } else {
+                        self.banner.showOffline("오프라인입니다")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AIProject/iCo/Features/Base/Banner/BannerController.swift
+++ b/AIProject/iCo/Features/Base/Banner/BannerController.swift
@@ -1,0 +1,40 @@
+//
+//  BannerController.swift
+//  iCo
+//
+//  Created by Kanghos on 9/18/25.
+//
+
+import Foundation
+import Observation
+
+@Observable
+final class TopBannerController {
+    enum Kind { case online, offline }
+
+    var isVisible: Bool = false
+    var message: String = ""
+    var kind: Kind = .offline
+
+    private var hideTask: Task<Void, Never>?
+
+    func showOffline(_ text: String = "오프라인입니다. 네트워크에 연결해 주세요.") {
+        hideTask?.cancel()
+        kind = .offline
+        message = text
+        isVisible = true                 // 항상 표시 (자동 숨김 없음)
+    }
+
+    func showOnline(_ text: String = "온라인 복귀!") {
+        hideTask?.cancel()
+        kind = .online
+        message = text
+        isVisible = true
+        // 3초 후 자동 숨김
+        hideTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: 3_000_000_000) // 3s 후 숨김
+            await MainActor.run { self.isVisible = false }
+        }
+    }
+}

--- a/AIProject/iCo/Features/Base/Banner/TopBannerView.swift
+++ b/AIProject/iCo/Features/Base/Banner/TopBannerView.swift
@@ -1,0 +1,42 @@
+//
+//  TopBannerView.swift
+//  iCo
+//
+//  Created by Kanghos on 9/18/25.
+//
+
+import SwiftUI
+
+struct TopBannerView: View {
+    @Bindable var controller: TopBannerController
+
+    var body: some View {
+        if controller.isVisible {
+            HStack(spacing: 8) {
+                Image(systemName: controller.kind == .offline ? "wifi.slash" : "wifi")
+                    .font(.headline)
+                Text(controller.message)
+                    .font(.subheadline).bold()
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(background)
+            .overlay(Divider(), alignment: .bottom)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .animation(.snappy, value: controller.isVisible)
+        }
+    }
+
+    private var background: some View {
+        Group {
+            switch controller.kind {
+            case .offline:
+                Color.red.opacity(0.95)
+            case .online:
+                Color.green.opacity(0.95)
+            }
+        }
+        .ignoresSafeArea(edges: .top) // 상태바까지 꽉 차게
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## 📝 작업 내용
- 네트워크 모니터
- 네트워크 연결 알림 배너

활용 용도
- 네트워크 retrier
- UI 알림 용도
- 소켓 재연결 시 원인 파악

사용 프로퍼티
```swift
    private(set) var isOnline: Bool = true
    /// Cellular, Hotspot
    private(set) var isExpensive: Bool = false
    /// 네트워크 절약 모드
    private(set) var isConstrained: Bool = false
    /// wifi, cellular
    private(set) var interface: NWInterface.InterfaceType? = nil
```

### 스크린샷 
https://github.com/user-attachments/assets/952ba533-d5f0-4126-bf4e-7a85f1efa413 

(선택)

## 💬 리뷰 요구사항(선택)

파일 위치
- Core/Remote/NetworkMoniter
- Feature/Base/Banner/...
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
