### PR TITLE
마이페이지 상단 separator / MainTabView init이 여러번 호출되는 이유 / 리포트 뉴스 원문보기 보류

### DIFF
--- a/AIProject/iCo/App/Source/iCoApp.swift
+++ b/AIProject/iCo/App/Source/iCoApp.swift
@@ -24,7 +24,6 @@ struct iCoApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     @StateObject private var themeManager = ThemeManager()
-    @StateObject private var recommendCoinViewModel = RecommendCoinViewModel()
     @State private var coinStore: CoinStore = .init(
         coinService: DefaultCoinService(network: NetworkClient())
     )
@@ -47,7 +46,6 @@ struct iCoApp: App {
                             removal: .opacity.animation(.easeOut(duration: 0.3))
                         ))
                         .zIndex(1)
-                        .environmentObject(recommendCoinViewModel)
                 } else {
                     if hasSeenOnboarding {
                         MainTabView(
@@ -60,10 +58,8 @@ struct iCoApp: App {
                         })
                         .environment(\.managedObjectContext, persistenceController.container.viewContext)
                         .environmentObject(themeManager)
-                        .environmentObject(recommendCoinViewModel)
                     } else {
                         OnboardingView()
-                            .environmentObject(recommendCoinViewModel)
                     }
                 }
             }
@@ -78,9 +74,7 @@ struct iCoApp: App {
 }
 
 struct SplashScreenView: View {
-    @AppStorage("hasSeenOnboarding") var hasSeenOnboarding: Bool = false
     @Binding var isLoading: Bool
-    @EnvironmentObject var recommendCoinViewModel: RecommendCoinViewModel
     @Environment(CoinStore.self) var coinStore
 
     var body: some View {
@@ -96,8 +90,7 @@ struct SplashScreenView: View {
                 .frame(height: 100)
         }
         .task {
-            if hasSeenOnboarding { recommendCoinViewModel.loadRecommendCoin() }
-            Task { await coinStore.loadCoins() }
+            await coinStore.loadCoins()
             try? await Task.sleep(for: .seconds(3))
             await MainActor.run {
                 isLoading = false

--- a/AIProject/iCo/Features/CoinDetail/View/ReportNewsSectionView.swift
+++ b/AIProject/iCo/Features/CoinDetail/View/ReportNewsSectionView.swift
@@ -42,11 +42,11 @@ struct ReportNewsSectionView: View {
                         
                         Spacer()
                         
-                        RoundedButton(title: "원문보기", imageName: "chevron.right") {
-                             if let url = URL(string: article.newsSourceURL) {
-                                 safariItem = IdentifiableURL(url: url)
-                             }
-                        }
+//                        RoundedButton(title: "원문보기", imageName: "chevron.right") {
+//                             if let url = URL(string: article.newsSourceURL) {
+//                                 safariItem = IdentifiableURL(url: url)
+//                             }
+//                        }
                     }
                     
                     Text(article.summary.byCharWrapping)

--- a/AIProject/iCo/Features/Dashboard/View/RecommendCoinView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/RecommendCoinView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecommendCoinView: View {
-    @EnvironmentObject var viewModel: RecommendCoinViewModel
+    @StateObject private var viewModel = RecommendCoinViewModel()
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -32,6 +32,9 @@ struct RecommendCoinView: View {
             }
         }
         .padding(.bottom, 40)
+        .task {
+            viewModel.loadRecommendCoin() 
+        }
     }
     
     @ViewBuilder

--- a/AIProject/iCo/Features/Market/MarketView.swift
+++ b/AIProject/iCo/Features/Market/MarketView.swift
@@ -110,7 +110,6 @@ extension MarketView {
             }
             .padding(.vertical, 20)
         }
-        .background(.background)
     }
 }
 

--- a/AIProject/iCo/Features/MyPage/View/Main/MyPageView.swift
+++ b/AIProject/iCo/Features/MyPage/View/Main/MyPageView.swift
@@ -83,6 +83,7 @@ struct MyPageView: View {
                         .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 )
                 .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
                 
                 VStack {
                     Section {
@@ -115,6 +116,7 @@ struct MyPageView: View {
                         .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 )
                 .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
             }
             .listStyle(.plain)
         }

--- a/AIProject/iCo/Features/MyPage/View/Main/MyPageView.swift
+++ b/AIProject/iCo/Features/MyPage/View/Main/MyPageView.swift
@@ -82,6 +82,7 @@ struct MyPageView: View {
                         .fill(.aiCoBackground)
                         .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 )
+                .listRowSeparator(.hidden)
                 
                 VStack {
                     Section {

--- a/AIProject/iCo/Features/Onboarding/LastOnboardingPage.swift
+++ b/AIProject/iCo/Features/Onboarding/LastOnboardingPage.swift
@@ -56,8 +56,6 @@ struct LastOnboardingPage: View {
                 ) {
                     if let selected = selectedType {
                         storedInvestmentType = selected.rawValue
-                        
-                        recommendCoinViewModel.loadRecommendCoin(selectedPreference: storedInvestmentType)
                     }
                     onFinish()
                 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- close #523 
- close #526 
- close #538 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
1. 마이페이지 상단에 separator는 List에서 생기는 separator였습니다.
    - List의 첫번째 VStack에 `.listRowSeparator(.hidden)`을 추가해서 해결했습니다.
2. MainTabView의 init이 여러번 생성되던 문제
    - MainTabView가 여러개 생기던 건 아니었습니다.
    - RecommendViewModel을 iCoApp에서 생성하고 environment로 주입하고 있었는데, 해당 vm의 Published가 변경되면서 vm을 생성한 View(iCoApp)의 body까지 리렌더링이 전파되어서 생긴 문제였습니다. 실제로 상태가 바뀔 때마다 MainTabView의 init이 호출되는 것을 확인했습니다.
    - 기존 LLM의 응답이 느려서, 시간을 조금 줄이고자 RecommendViewModel을 App에서 생성하고있었는데, LLM을 교체한 뒤 속도가 개선되어 해당 View로 생성과 네트워크를 옮겼습니다.
3. 코인 상세 리포트의 뉴스 원문보기는 Flash로 바꿔봤음에도 적절한 링크를 제공하지 않아, 1차 배포 후 프롬프팅을 다시 해볼 계획입니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
