### PR TITLE
[hotfix] 아이패드에서 배경 카드의 최대 크기 제한이 반영 안되는 이슈 수정하기

### DIFF
--- a/AIProject/iCo/Features/Dashboard/View/RecomendationPlaceholderCardView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/RecomendationPlaceholderCardView.swift
@@ -42,11 +42,11 @@ struct RecomendationPlaceholderCardView: View {
                     }
                     
                     Card()
+                        .frame(maxWidth: hSizeClass == .compact ? .infinity : 500)
                         .frame(
                             width: viewWidth - (CardConst.cardInnerPadding * 2) - (.spacingXSmall * 2),
                             height: CardConst.cardHeight
                         )
-                        .frame(maxWidth: hSizeClass == .compact ? .infinity : 500)
                     
                     if hSizeClass == .compact {
                         Card()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

지난 PR 때 아이패드에서 배경 카드의 최대 크기 제한이 반영되지 않는 것을
아래와 같이 대빵만하게 나오는 것을 머지 후에 발견했네요!

modifier 순서 바꿔서 빠르게 해결했습니다!

### 스크린샷 (선택)

<img width="400" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2025-10-01 at 20 58 47" src="https://github.com/user-attachments/assets/9be6f89d-e0b3-49a0-b44d-641d0e876817" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
