### PR TITLE
이미지 파이프라인

### DIFF
--- a/AIProject/iCo/Features/Base/CachedAsyncImage.swift
+++ b/AIProject/iCo/Features/Base/CachedAsyncImage.swift
@@ -12,6 +12,19 @@ enum CoinResource {
     case symbol(String)
 }
 
+extension CoinResource: Equatable {
+    static func ==(lhs: CoinResource, rhs: CoinResource) -> Bool {
+        switch (lhs, rhs) {
+        case (.url(let lhsURL), .url(let rhsURL)):
+            return lhsURL == rhsURL
+        case (.symbol(let lhsSymbol), .symbol(let rhsSymbol)):
+            return lhsSymbol == rhsSymbol
+        default:
+            return false
+        }
+    }
+}
+
 struct CachedAsyncImage<Content: View>: View {
     let resource: CoinResource
     let useCacheOnly: Bool
@@ -41,7 +54,7 @@ struct CachedAsyncImage<Content: View>: View {
                 placeholder
             }
         }
-        .task {
+        .task(id: resource) {
             await loadImage()
         }
     }
@@ -54,7 +67,7 @@ struct CachedAsyncImage<Content: View>: View {
         } catch {
             if let error = error as? URLError, error.code == .fileDoesNotExist {
                 // TODO: Retry fallback
-                print(error)
+                print("image 불러오기 실패")
             }
             image = nil
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #461 

## 📝 작업 내용

- [ ] 이미지 URL 없을 시, 코인 게코에서 imageURL 얻은 후, 매핑 정보 저장, 이미지 로드
- [ ] task(id: )를 이용하여 이미지 로드 중복 task 최적화
  - 이미지 key(url or symbol)가 동일하면 task 재요청 안 함

## 💬 리뷰 요구사항(선택)

- 코인게코 이미지 제공처와 업비트의  id, symbol이 달라서 해결할 수 없음
  예를 들어 gamebuild 코인의 경우, 업비트는 game2 /  게코는 game
  tokamak 코인은 ton / tokamak 등
  이를 위해 매번 클라이언트 업데이트할 수 없음 해결 방법 고민

- 현재 범용적인 이미지 로더에 코인 specific한 로직이 다수 들어있어 분리해야하는데 아이디어가 있으면 주면 감사하겠습니다.
 